### PR TITLE
Create dict rather than a set of symbols

### DIFF
--- a/implib-gen.py
+++ b/implib-gen.py
@@ -68,7 +68,7 @@ def main():
         n = n.replace(':', '')
         hdr[i] = n
     elif hdr is not None:
-      sym = {(k, words[i]) for i, k in hdr.items()}
+      sym = {k: words[i] for (i, k) in hdr.items()}
       if sym['Name'].find('@') >= 0:
         name, ver = sym['Name'].split('@')
         sym['Name'] = name


### PR DESCRIPTION
I was receiving the error:

  File "../../implib-gen.py", line 73, in main
    if sym['Name'].find('@') >= 0:
TypeError: 'set' object is not subscriptable

This change allows the code to work properly on python 2.7 and 3.4

Signed-off-by: Jon Nettleton <jon@solid-run.com>