### PR TITLE
aarch64: access stack in pairs of registers

### DIFF
--- a/arch/aarch64/trampoline.S.tpl
+++ b/arch/aarch64/trampoline.S.tpl
@@ -26,13 +26,9 @@ $sym:
 2:
   // Slow path
   mov ip0, $number
-  str ip0, [sp, #-8]!
-  .cfi_adjust_cfa_offset 8
-  PUSH_REG(lr)
+  stp ip0, lr, [sp, #-16]!; .cfi_adjust_cfa_offset 16; .cfi_rel_offset ip0, 0; .cfi_rel_offset lr, 8;
   bl _${lib_suffix}_save_regs_and_resolve
-  POP_REG(lr)
-  add sp, sp, #8
-  .cfi_adjust_cfa_offset -8
+  ldp ip0, lr, [sp], #16; .cfi_adjust_cfa_offset -16; .cfi_restore lr; .cfi_restore ip0
   b 1b
   .cfi_endproc
 

--- a/implib-gen.py
+++ b/implib-gen.py
@@ -100,6 +100,7 @@ def main():
   parser.add_argument('-q', '--quiet',
                       help="Do not print progress info.",
                       action='store_true')
+  parser.add_argument('--outdir', help="Path to create wrapper at", default='./')
 
   args = parser.parse_args()
 
@@ -111,6 +112,7 @@ def main():
   load_name = args.library_load_name if args.library_load_name is not None else os.path.basename(input_name)
   target = args.target.split('-')[0]
   quiet = args.quiet
+  outdir = args.outdir
 
   if args.symbol_list is None:
     funs = None
@@ -164,7 +166,7 @@ def main():
   lib_suffix = re.sub(r'[^a-zA-Z_0-9]+', '_', suffix)
 
   tramp_file = '%s.tramp.S' % suffix
-  with open(tramp_file, 'w') as f:
+  with open(os.path.join(outdir, tramp_file), 'w') as f:
     if not quiet:
       print("Generating %s..." % tramp_file)
     with open(target_dir + '/table.S.tpl', 'r') as t:
@@ -187,7 +189,7 @@ def main():
   # Generate C code
 
   init_file = '%s.init.c' % suffix
-  with open(init_file, 'w') as f:
+  with open(os.path.join(outdir, init_file), 'w') as f:
     if not quiet:
       print("Generating %s..." % init_file)
     with open(os.path.join(root, 'arch/common/init.c.tpl'), 'r') as t:


### PR DESCRIPTION
On aarch64 CPUs load and store addresses have to be aligned to multiples
of 16. Otherwise an exception is thrown and the application receives a
SIGBUS. Unlike native CPUs, QEMU does not care about alignment here.

Use stp and ldp instructions for manipulating the stack in register
pairs which automaticlly leads to appropriately aligned addresses.

Signed-off-by: Josua Mayer <josua@solid-run.com>