### PR TITLE
Unset env var "LANG" in subprocess

### DIFF
--- a/implib-gen.py
+++ b/implib-gen.py
@@ -29,8 +29,13 @@ def error(msg):
 
 def run(args, input=''):
   """Runs external program and aborts on error."""
+  env = os.environ.copy()
+  try:
+    del env["LANG"]
+  except KeyError:
+    pass
   p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                       stderr=subprocess.PIPE)
+                       stderr=subprocess.PIPE, env=env)
   out, err = p.communicate(input=input.encode('utf-8'))
   out = out.decode('utf-8')
   err = err.decode('utf-8')


### PR DESCRIPTION
While using Implib.so, I got the Error showed in [0]. The call of readelf translates the word "Value" in the table head in the german word "Wert" [1], because the environment var `LANG` in my terminal is set to `de_DE.UTF-8`. After unsetting the env var, the code is working :)
In this pullrequest I added code to unset the env var in calls to subprocess. Maybe this will help some others.

Cheers
Rouven


[0]
```
$ python3 implib-gen.py /usr/lib/x86_64-linux-gnu/librt.so
Traceback (most recent call last):
  File "implib-gen.py", line 524, in <module>
    main()
  File "implib-gen.py", line 386, in main
    syms = list(filter(is_exported, collect_syms(input_name)))
  File "implib-gen.py", line 76, in collect_syms
    sym = parse_row(words, toc, ['Value'])
  File "implib-gen.py", line 51, in parse_row
    if vals[k]:

```

[1]
```
$ readelf -W --dyn-syms libmimetic.so
Symbol table '.dynsym' contains 866 entries:
   Num:    Wert           Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND 
...
```