### PR TITLE
Allow wrapping symbols that are explicitly versioned with the default…

### DIFF
--- a/implib-gen.py
+++ b/implib-gen.py
@@ -430,7 +430,7 @@ Examples:
   all_funs = set()
   warn_versioned = False
   for s in orig_funs:
-    if s['Version'] is not None:
+    if not s['Default']:
       # TODO: support versions
       if not warn_versioned:
         warn(f"library {input_name} contains versioned symbols which are NYI")


### PR DESCRIPTION
… version.

Instead of checking if a symbol has a version (which makes no distinction
between default and non-default versions), check whether the symbol has a
non-default version instead.