### PR TITLE
Allow providing custom dlsym() replacement.

### DIFF
--- a/arch/common/init.c.tpl
+++ b/arch/common/init.c.tpl
@@ -36,7 +36,8 @@ extern "C" {
     } \
   } while(0)
 
-#define CALL_USER_CALLBACK $has_dlopen_callback
+#define HAS_DLOPEN_CALLBACK $has_dlopen_callback
+#define HAS_DLSYM_CALLBACK $has_dlsym_callback
 #define NO_DLOPEN $no_dlopen
 #define LAZY_LOAD $lazy_load
 
@@ -51,7 +52,7 @@ static void *load_library() {
 
   is_lib_loading = 1;
 
-#if CALL_USER_CALLBACK
+#if HAS_DLOPEN_CALLBACK
   extern void *$dlopen_callback(const char *lib_name);
   lib_handle = $dlopen_callback("$load_name");
   CHECK(lib_handle, "failed to load library via callback '$dlopen_callback'");
@@ -116,8 +117,13 @@ void _${lib_suffix}_tramp_resolve(int i) {
   CHECK(h, "failed to resolve symbol '%s', library failed to load", sym_names[i]);
 #endif
 
+#if HAS_DLSYM_CALLBACK
+  extern void *$dlsym_callback(void*, const char *lib_name);
+  _${lib_suffix}_tramp_table[i] = $dlsym_callback(h, sym_names[i]);
+#else
   // Dlsym is thread-safe so don't need to protect it.
   _${lib_suffix}_tramp_table[i] = dlsym(h, sym_names[i]);
+#endif
   CHECK(_${lib_suffix}_tramp_table[i], "failed to resolve symbol '%s'", sym_names[i]);
 }
 

--- a/implib-gen.py
+++ b/implib-gen.py
@@ -329,6 +329,10 @@ Examples:
   parser.add_argument('--dlopen-callback',
                       help="Call user-provided custom callback to load library instead of dlopen",
                       default='')
+  parser.add_argument('--dlsym-callback',
+                      help="Call user-provided custom callback to resolve a symbol, "
+                           "instead of dlsym",
+                      default='')
   parser.add_argument('--library-load-name',
                       help="Use custom name for dlopened library (default is LIB)")
   parser.add_argument('--lazy-load',
@@ -367,6 +371,7 @@ Examples:
   input_name = args.library
   verbose = args.verbose
   dlopen_callback = args.dlopen_callback
+  dlsym_callback = args.dlsym_callback
   dlopen = args.dlopen
   lazy_load = args.lazy_load
   load_name = args.library_load_name or os.path.basename(input_name)
@@ -540,7 +545,9 @@ Examples:
         lib_suffix=lib_suffix,
         load_name=load_name,
         dlopen_callback=dlopen_callback,
+        dlsym_callback=dlsym_callback,
         has_dlopen_callback=int(bool(dlopen_callback)),
+        has_dlsym_callback=int(bool(dlsym_callback)),
         no_dlopen=int(not dlopen),
         lazy_load=int(lazy_load),
         sym_names=sym_names)


### PR DESCRIPTION
It's useful when one needs to provide special-case handling of symbols
(e.g. providea an error-returning stub if a symbol is missing).